### PR TITLE
Feat: add delete methods

### DIFF
--- a/src/main/kotlin/br/com/creditas/credit_analysis/controller/ClientController.kt
+++ b/src/main/kotlin/br/com/creditas/credit_analysis/controller/ClientController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import java.util.UUID
 import java.util.Optional
@@ -97,5 +98,19 @@ class ClientController(
     @ResponseStatus(HttpStatus.OK)
     fun getByCpf(@RequestParam cpf: String): ClientPF {
         return clientRepository.findByCpf(cpf)
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Transactional
+    fun deleteClient(@PathVariable id: UUID) {
+        clientRepository.deleteById(id)
+    }
+
+    @DeleteMapping("/delete")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Transactional
+    fun deleteClientByCpf(@RequestParam cpf: String) {
+        clientRepository.deleteByCpf(cpf)
     }
 }

--- a/src/main/kotlin/br/com/creditas/credit_analysis/repositories/ClientRepository.kt
+++ b/src/main/kotlin/br/com/creditas/credit_analysis/repositories/ClientRepository.kt
@@ -8,4 +8,6 @@ import java.util.UUID
 @Repository
 interface ClientRepository: JpaRepository<ClientPF, UUID> {
     fun findByCpf(cpf: String): ClientPF
+
+    fun deleteByCpf(cpf: String)
 }

--- a/src/main/resources/db/migration/V4__alter_table_address.sql
+++ b/src/main/resources/db/migration/V4__alter_table_address.sql
@@ -1,0 +1,9 @@
+ALTER TABLE address
+    DROP client_id;
+
+ALTER TABLE address
+    ADD client_id UUID NOT NULL;
+
+ALTER TABLE address
+    ADD FOREIGN KEY(client_id) REFERENCES client_pf(id)
+    ON DELETE CASCADE;


### PR DESCRIPTION
# Why?
We need methods to delete clients by id or cpf.

# How?
1) We use the **ON DELETE CASCADE** option to specify that rows are deleted in a child table when corresponding rows are deleted in the parent table 
2) We created queries using the JPA criteria API and new endpoints to delete by id or cpf.