### PR TITLE
Feat: update exception handler

### DIFF
--- a/src/main/kotlin/br/com/creditas/credit_analysis/controller/ClientController.kt
+++ b/src/main/kotlin/br/com/creditas/credit_analysis/controller/ClientController.kt
@@ -36,7 +36,7 @@ class ClientController(
     private val clientRepository: ClientRepository,
     private val addressRepository: AddressRepository,
     private val contactRepository: ContactRepository,
-    private val notFoundMessage: String = "Cliente não encontrado!"
+    private val notFoundMessage: String = "Client not found"
 ) {
 
     @PostMapping

--- a/src/main/kotlin/br/com/creditas/credit_analysis/exceptions/ExceptionHandler.kt
+++ b/src/main/kotlin/br/com/creditas/credit_analysis/exceptions/ExceptionHandler.kt
@@ -1,7 +1,9 @@
 package br.com.creditas.credit_analysis.exceptions
 
 import br.com.creditas.credit_analysis.requests.ErrorView
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -19,6 +21,52 @@ class ExceptionHandler {
             status = HttpStatus.NOT_FOUND.value(),
             error = HttpStatus.NOT_FOUND.name,
             message = exception.message,
+            path = request.servletPath
+        )
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException::class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun handleServerError(
+        exception: DataIntegrityViolationException,
+        request: HttpServletRequest
+    ): ErrorView {
+        return ErrorView(
+            status = HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            error = HttpStatus.INTERNAL_SERVER_ERROR.name,
+            message = "could not execute statement; SQL constraint violation exception",
+            path = request.servletPath
+        )
+    }
+
+    @ExceptionHandler(Exception::class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun handleServerError(
+        exception: Exception,
+        request: HttpServletRequest
+    ): ErrorView {
+        return ErrorView(
+            status = HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            error = HttpStatus.INTERNAL_SERVER_ERROR.name,
+            message = exception.message,
+            path = request.servletPath
+        )
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleBadRequest(
+        exception: MethodArgumentNotValidException,
+        request: HttpServletRequest
+    ): ErrorView {
+        val errorMessage = HashMap<String, String?>()
+        exception.bindingResult.fieldErrors.forEach { error ->
+            errorMessage[error.field] = error.defaultMessage
+        }
+        return ErrorView(
+            status = HttpStatus.BAD_REQUEST.value(),
+            error = HttpStatus.BAD_REQUEST.name,
+            message = errorMessage.toString(),
             path = request.servletPath
         )
     }

--- a/src/main/resources/db/migration/V5__alter_table_client_pf_add_constraint_unique.sql
+++ b/src/main/resources/db/migration/V5__alter_table_client_pf_add_constraint_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE client_pf
+    ADD UNIQUE(cpf)


### PR DESCRIPTION
# Why?
We need to return more semantic error messages to the user.

# How?
We created new exception handling for internal server errors and bad requests. And we added a constraint to the client_pf table to prevent more than one user from being registered with the same cpf.
